### PR TITLE
Updated Koan url, name and description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,7 +223,7 @@ My personal recommendation is (for now) to use the android api to build a native
 - [SwissKnife](https://github.com/Arasthel/SwissKnife) - A multi-purpose Groovy library containing view injection and threading for Android using annotations.
 
 ### Kotlin
-- [Koan](https://github.com/yanex/koan) - DSL for Android written in Kotlin.
+- [Anko](https://github.com/JetBrains/anko) - DSL for Android written in Kotlin by JetBrains.
 
 # Other Awesome Lists
 Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.


### PR DESCRIPTION
Updated Koan url, name and description since the one that´s on the readme redirects to Anko by JetBrains.
